### PR TITLE
Add secondary default route

### DIFF
--- a/build-deb/Makefile
+++ b/build-deb/Makefile
@@ -9,6 +9,7 @@ DIST        ?= unstable
 
 STAGING_DIR = $(abspath $(PROJECT)-$(VERSION))
 UPSTREAM_ARCHIVE = $(PROJECT)-$(VERSION).tar.gz
+UPSTREAM_ORIG_ARCHIVE = $(PROJECT)_$(VERSION).orig.tar.gz
 
 FILES = \
 	$(STAGING_DIR)/debian/changelog \
@@ -34,7 +35,8 @@ $(STAGING_DIR)/debian/%: $(PROJ_DIR)/build-deb/debian/%
 	cp $< $@
 
 extract-upstream:
-	tar zxf $(PROJ_DIR)/$(UPSTREAM_ARCHIVE)
+	cp -a $(PROJ_DIR)/$(UPSTREAM_ARCHIVE) $(UPSTREAM_ORIG_ARCHIVE)
+	tar zxf $(UPSTREAM_ORIG_ARCHIVE)
 
 changelog:
 	dch -v $(VERSION)-$(DEBVERSION) -D $(DIST) -M -u low \

--- a/build-deb/debian/postinst
+++ b/build-deb/debian/postinst
@@ -20,10 +20,10 @@ set -e
 
 case "$1" in
     configure)
-        pip install -r /tmp/packages/requirements.txt || \
-            pip install --no-index --find-links file:/tmp/packages \
-                -r /tmp/packages/requirements.txt
-	rm -rf /tmp/packages
+        pip install -r /tmp/sanji-bundle-route-packages/requirements.txt || \
+            pip install --no-index --find-links file:/tmp/sanji-bundle-route-packages \
+                -r /tmp/sanji-bundle-route-packages/requirements.txt
+	rm -rf /tmp/sanji-bundle-route-packages
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/build-deb/debian/rules
+++ b/build-deb/debian/rules
@@ -12,7 +12,7 @@
 DEB_PACKAGE := $(strip $(shell dh_listpackages -i 2>/dev/null || dh_listpackages -i))
 DEB_DESTDIR := $(CURDIR)/debian/$(DEB_PACKAGE)
 
-DEB_PYPDIR  := $(DEB_DESTDIR)/tmp/packages
+DEB_PYPDIR  := $(DEB_DESTDIR)/tmp/$(DEB_PACKAGE)-packages
 
 
 %:

--- a/build-deb/debian/source/format
+++ b/build-deb/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/bundle.json
+++ b/bundle.json
@@ -17,11 +17,15 @@
   "resources": [
     {
       "role": "view",
-      "resource": "/network/interfaces"
+      "resource": "/network/interface"
     },
     {
       "methods": ["get"],
       "resource": "/network/routes/interfaces"
+    },
+    {
+      "methods": ["get","put"],
+      "resource": "/network/routes/db"
     },
     {
       "methods": ["get","put"],

--- a/data/route.json.factory
+++ b/data/route.json.factory
@@ -1,3 +1,3 @@
 {
-	"interface": "eth0"
+	"default": "eth0"
 }

--- a/data/route.json.factory
+++ b/data/route.json.factory
@@ -1,3 +1,3 @@
 {
-	"default": "eth0"
+	"interface": "eth0"
 }

--- a/route.py
+++ b/route.py
@@ -300,7 +300,12 @@ class IPRoute(Sanji):
         Update the secondary default gateway, delete default gateway if data
         is None or empty.
         """
-        self.set_default(message.data, False)
+        try:
+            self.set_default(message.data, False)
+        except Exception as e:
+            return response(code=404,
+                            data={"message": e})
+        return response(data=message.data)
 
     def set_router_db(self, message, response):
         """

--- a/route.py
+++ b/route.py
@@ -117,7 +117,7 @@ class IPRoute(Sanji):
         """
         Update DNS according to default gateway's interface.
 
-        Args: 
+        Args:
             default: interface name
         """
         res = self.publish.put("/network/dns", data={"interface": interface})

--- a/route.py
+++ b/route.py
@@ -84,7 +84,7 @@ class IPRoute(Sanji):
             self.update_default(default)
         else:
             self.cellular = None
-            if name == self.model.db["interface"]:
+            if name == self.model.db["default"]:
                 self.update_default(default)
 
     def list_interfaces(self):
@@ -161,7 +161,7 @@ class IPRoute(Sanji):
                     ip.route.add("default", default["interface"])
             except Exception as e:
                 raise e
-            self.model.db["interface"] = default["interface"]
+            self.model.db["default"] = default["interface"]
 
         # delete the default gateway
         else:
@@ -169,8 +169,8 @@ class IPRoute(Sanji):
                 ip.route.delete("default")
             except Exception as e:
                 raise e
-            if "interface" in self.model.db:
-                self.model.db.pop("interface")
+            if "default" in self.model.db:
+                self.model.db.pop("default")
 
         self.save()
 
@@ -199,7 +199,7 @@ class IPRoute(Sanji):
             self.interfaces.append(iface)
 
         # check if the default gateway need to be modified
-        if iface["interface"] == self.model.db["interface"]:
+        if iface["interface"] == self.model.db["default"]:
             try:
                 self.update_default(iface)
             except:
@@ -219,8 +219,8 @@ class IPRoute(Sanji):
         Get default gateway.
         """
         default = self.list_default()
-        if self.model.db and "interface" in self.model.db and default and \
-                self.model.db["interface"] == default["interface"]:
+        if self.model.db and "default" in self.model.db and default and \
+                self.model.db["default"] == default["interface"]:
             return response(data=default)
         return response(data=self.model.db)
 

--- a/route.py
+++ b/route.py
@@ -96,10 +96,6 @@ class IPRoute(Sanji):
             ifaces = ip.addr.interfaces()
         except:
             return {}
-        """
-        except Exception as e:
-            raise e
-        """
 
         # list connected interfaces
         data = []
@@ -263,8 +259,30 @@ class IPRoute(Sanji):
                                   "Update default gateway failed: %s"
                                   % e})
 
-    @Route(methods="put", resource="/network/interfaces")
-    def _event_router_info(self, message):
+    def set_router_db(self, message, response):
+        """
+        Update router database batch or by interface.
+        """
+        if type(message.data) is list:
+            for iface in message.data:
+                self.update_interface_router(iface)
+            return response(data=self.interfaces)
+        elif type(message.data) is dict:
+            self.update_interface_router(message.data)
+            return response(data=message.data)
+        return response(code=400,
+                            data={"message": "Wrong type of router database."})
+
+    @Route(methods="put", resource="/network/routes/db")
+    def _set_router_db(self, message, response):
+        return self.set_router_db(message, response)
+
+    @Route(methods="get", resource="/network/routes/db")
+    def _get_router_db(self, message, response):
+        return response(data=self.interfaces)
+
+    @Route(methods="put", resource="/network/interface")
+    def _event_router_db(self, message):
         self.update_interface_router(message.data)
 
     '''

--- a/route.py
+++ b/route.py
@@ -84,7 +84,7 @@ class IPRoute(Sanji):
             self.update_default(default)
         else:
             self.cellular = None
-            if name == self.model.db["default"]:
+            if name == self.model.db["interface"]:
                 self.update_default(default)
 
     def list_interfaces(self):
@@ -161,7 +161,7 @@ class IPRoute(Sanji):
                     ip.route.add("default", default["interface"])
             except Exception as e:
                 raise e
-            self.model.db["default"] = default["interface"]
+            self.model.db["interface"] = default["interface"]
 
         # delete the default gateway
         else:
@@ -169,8 +169,8 @@ class IPRoute(Sanji):
                 ip.route.delete("default")
             except Exception as e:
                 raise e
-            if "default" in self.model.db:
-                self.model.db.pop("default")
+            if "interface" in self.model.db:
+                self.model.db.pop("interface")
 
         self.save()
 
@@ -199,7 +199,7 @@ class IPRoute(Sanji):
             self.interfaces.append(iface)
 
         # check if the default gateway need to be modified
-        if iface["interface"] == self.model.db["default"]:
+        if iface["interface"] == self.model.db["interface"]:
             try:
                 self.update_default(iface)
             except:
@@ -219,8 +219,8 @@ class IPRoute(Sanji):
         Get default gateway.
         """
         default = self.list_default()
-        if self.model.db and "default" in self.model.db and default and \
-                self.model.db["default"] == default["interface"]:
+        if self.model.db and "interface" in self.model.db and default and \
+                self.model.db["interface"] == default["interface"]:
             return response(data=default)
         return response(data=self.model.db)
 

--- a/route.py
+++ b/route.py
@@ -108,7 +108,7 @@ class IPRoute(Sanji):
                 data.append(iface)
         return data
 
-    def list_default(self):
+    def get_default(self):
         """
         Retrieve the default gateway
 
@@ -180,7 +180,7 @@ class IPRoute(Sanji):
 
         self.save()
 
-    def update_interface_router(self, interface):
+    def update_router(self, interface):
         """
         Save the interface name with its gateway and update the default
         gateway if needed.
@@ -224,7 +224,7 @@ class IPRoute(Sanji):
         """
         Get default gateway.
         """
-        default = self.list_default()
+        default = self.get_default()
         # FIXME: show real time value instead of settings?
         if self.model.db and "interface" in self.model.db and default and \
                 self.model.db["interface"] == default["interface"]:
@@ -249,7 +249,7 @@ class IPRoute(Sanji):
                             data={"message": "Invalid input: %s." % e})
 
         # retrieve the default gateway
-        default = self.list_default()
+        default = self.get_default()
         try:
             self.update_default(message.data)
             return response(data=self.model.db)
@@ -272,13 +272,13 @@ class IPRoute(Sanji):
         """
         if type(message.data) is list:
             for iface in message.data:
-                self.update_interface_router(iface)
+                self.update_router(iface)
             return response(data=self.interfaces)
         elif type(message.data) is dict:
-            self.update_interface_router(message.data)
+            self.update_router(message.data)
             return response(data=message.data)
         return response(code=400,
-                            data={"message": "Wrong type of router database."})
+                        data={"message": "Wrong type of router database."})
 
     @Route(methods="put", resource="/network/routes/db")
     def _set_router_db(self, message, response):
@@ -290,7 +290,7 @@ class IPRoute(Sanji):
 
     @Route(methods="put", resource="/network/interface")
     def _event_router_db(self, message):
-        self.update_interface_router(message.data)
+        self.update_router(message.data)
 
 
 if __name__ == "__main__":

--- a/tests/data/route.json.factory
+++ b/tests/data/route.json.factory
@@ -1,3 +1,3 @@
 {
-	"interface": "eth0"
+	"default": "eth0"
 }

--- a/tests/data/route.json.factory
+++ b/tests/data/route.json.factory
@@ -1,3 +1,3 @@
 {
-	"default": "eth0"
+	"interface": "eth0"
 }

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -484,9 +484,9 @@ class TestIPRouteClass(unittest.TestCase):
                       self.bundle.interfaces)
 
     @patch.object(IPRoute, "get_default")
-    @patch.object(IPRoute, 'update_default')
+    @patch.object(IPRoute, 'try_update_default')
     def test__update_router__update_default(
-            self, mock_update_default, mock_get_default):
+            self, mock_try_update_default, mock_get_default):
         """
         update_router: default gateway should also be updated
         """
@@ -509,7 +509,7 @@ class TestIPRouteClass(unittest.TestCase):
                       self.bundle.interfaces)
         self.assertIn({"interface": "eth1", "gateway": "192.168.4.254"},
                       self.bundle.interfaces)
-        mock_update_default.assert_called_once_with(self.bundle.interfaces[0])
+        mock_try_update_default.assert_called_once_with(self.bundle.model.db)
 
     @patch.object(IPRoute, "update_default")
     def test__set_default__default(self, mock_update_default):

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -195,9 +195,11 @@ class TestIPRouteClass(unittest.TestCase):
         default = self.bundle.get_default()
         self.assertEqual({}, default)
 
+    @patch.object(IPRoute, "update_dns")
     @patch("route.ip.route.delete")
     @patch("route.ip.route.add")
-    def test__update_default(self, mock_ip_route_add, mock_ip_route_del):
+    def test__update_default(self, mock_ip_route_add, mock_ip_route_del,
+                             mock_update_dns):
         """
         update_default: update the default gateway with both interface and
                         gateway
@@ -211,10 +213,11 @@ class TestIPRouteClass(unittest.TestCase):
         except:
             self.fail("update_default raised exception unexpectedly!")
 
+    @patch.object(IPRoute, "update_dns")
     @patch("route.ip.route.delete")
     @patch("route.ip.route.add")
     def test__update_default__with_iface(self, mock_ip_route_add,
-                                         mock_ip_route_del):
+                                         mock_ip_route_del, mock_update_dns):
         """
         update_default: update the default gateway with interface
         """

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -63,7 +63,7 @@ class TestIPRouteClass(unittest.TestCase):
         self.bundle = IPRoute(connection=Mockup())
 
     def tearDown(self):
-        #self.bundle.stop()
+        self.bundle.stop()
         self.bundle = None
         try:
             os.remove("%s/data/%s.json" % (dirpath, self.name))

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -86,13 +86,13 @@ class TestIPRouteClass(unittest.TestCase):
     def test__load__current_conf(self):
         # case: load current configuration
         self.bundle.load(dirpath)
-        self.assertEqual("eth0", self.bundle.model.db["default"])
+        self.assertEqual("eth0", self.bundle.model.db["interface"])
 
     def test__load__backup_conf(self):
         # case: load backup configuration
         os.remove("%s/data/%s.json" % (dirpath, self.name))
         self.bundle.load(dirpath)
-        self.assertEqual("eth0", self.bundle.model.db["default"])
+        self.assertEqual("eth0", self.bundle.model.db["interface"])
 
     def test__load__no_conf(self):
         # case: cannot load any configuration
@@ -198,7 +198,7 @@ class TestIPRouteClass(unittest.TestCase):
         # case: delete the default gateway
         default = dict()
         self.bundle.update_default(default)
-        self.assertNotIn("default", self.bundle.model.db)
+        self.assertNotIn("interface", self.bundle.model.db)
 
     @patch("route.ip.route.delete")
     def test__update_default__delete_failed(self, mock_route_delete):
@@ -208,7 +208,7 @@ class TestIPRouteClass(unittest.TestCase):
         default = dict()
         with self.assertRaises(IOError):
             self.bundle.update_default(default)
-        self.assertIn("default", self.bundle.model.db)
+        self.assertIn("interface", self.bundle.model.db)
 
     @patch("route.ip.route.add")
     @patch("route.ip.route.delete")
@@ -221,7 +221,7 @@ class TestIPRouteClass(unittest.TestCase):
         default = dict()
         default["interface"] = "eth1"
         self.bundle.update_default(default)
-        self.assertIn("eth1", self.bundle.model.db["default"])
+        self.assertIn("eth1", self.bundle.model.db["interface"])
 
     @patch("route.ip.route.add")
     @patch("route.ip.route.delete")
@@ -235,7 +235,7 @@ class TestIPRouteClass(unittest.TestCase):
         default["interface"] = "eth1"
         default["gateway"] = "192.168.4.254"
         self.bundle.update_default(default)
-        self.assertIn("eth1", self.bundle.model.db["default"])
+        self.assertIn("eth1", self.bundle.model.db["interface"])
 
     @patch.object(IPRoute, 'list_interfaces')
     def test__update_default__add_failed_iface_down(
@@ -249,7 +249,7 @@ class TestIPRouteClass(unittest.TestCase):
         default["gateway"] = "192.168.4.254"
         with self.assertRaises(ValueError):
             self.bundle.update_default(default)
-        self.assertIn("default", self.bundle.model.db)
+        self.assertIn("interface", self.bundle.model.db)
 
     @patch.object(IPRoute, 'list_interfaces')
     def test__update_default__add_failed_cellular_connected(
@@ -405,7 +405,7 @@ class TestIPRouteClass(unittest.TestCase):
 
         def resp(code=200, data=None):
             self.assertEqual(200, code)
-            self.assertEqual("eth0", data["default"])
+            self.assertEqual("eth0", data["interface"])
         self.bundle._get_default(message=message, response=resp, test=True)
 
     def test__get_default__empty(self):

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -533,9 +533,9 @@ class TestIPRouteClass(unittest.TestCase):
     @patch.object(IPRoute, "try_update_default")
     @patch.object(IPRoute, "update_default")
     def test__set_default__update_default_failed(
-        self,
-        mock_update_default,
-        mock_try_update_default):
+            self,
+            mock_update_default,
+            mock_try_update_default):
         """
         set_default: update default gateway failed
         """
@@ -559,9 +559,9 @@ class TestIPRouteClass(unittest.TestCase):
     @patch.object(IPRoute, "try_update_default")
     @patch.object(IPRoute, "update_default")
     def test__set_default__update_default_and_recovery_failed(
-        self,
-        mock_update_default,
-        mock_try_update_default):
+            self,
+            mock_update_default,
+            mock_try_update_default):
         """
         set_default: update default gateway failed and recovery failed
         """

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -86,13 +86,13 @@ class TestIPRouteClass(unittest.TestCase):
     def test__load__current_conf(self):
         # case: load current configuration
         self.bundle.load(dirpath)
-        self.assertEqual("eth0", self.bundle.model.db["interface"])
+        self.assertEqual("eth0", self.bundle.model.db["default"])
 
     def test__load__backup_conf(self):
         # case: load backup configuration
         os.remove("%s/data/%s.json" % (dirpath, self.name))
         self.bundle.load(dirpath)
-        self.assertEqual("eth0", self.bundle.model.db["interface"])
+        self.assertEqual("eth0", self.bundle.model.db["default"])
 
     def test__load__no_conf(self):
         # case: cannot load any configuration
@@ -198,7 +198,7 @@ class TestIPRouteClass(unittest.TestCase):
         # case: delete the default gateway
         default = dict()
         self.bundle.update_default(default)
-        self.assertNotIn("interface", self.bundle.model.db)
+        self.assertNotIn("default", self.bundle.model.db)
 
     @patch("route.ip.route.delete")
     def test__update_default__delete_failed(self, mock_route_delete):
@@ -208,7 +208,7 @@ class TestIPRouteClass(unittest.TestCase):
         default = dict()
         with self.assertRaises(IOError):
             self.bundle.update_default(default)
-        self.assertIn("interface", self.bundle.model.db)
+        self.assertIn("default", self.bundle.model.db)
 
     @patch("route.ip.route.add")
     @patch("route.ip.route.delete")
@@ -221,7 +221,7 @@ class TestIPRouteClass(unittest.TestCase):
         default = dict()
         default["interface"] = "eth1"
         self.bundle.update_default(default)
-        self.assertIn("eth1", self.bundle.model.db["interface"])
+        self.assertIn("eth1", self.bundle.model.db["default"])
 
     @patch("route.ip.route.add")
     @patch("route.ip.route.delete")
@@ -235,7 +235,7 @@ class TestIPRouteClass(unittest.TestCase):
         default["interface"] = "eth1"
         default["gateway"] = "192.168.4.254"
         self.bundle.update_default(default)
-        self.assertIn("eth1", self.bundle.model.db["interface"])
+        self.assertIn("eth1", self.bundle.model.db["default"])
 
     @patch.object(IPRoute, 'list_interfaces')
     def test__update_default__add_failed_iface_down(
@@ -249,7 +249,7 @@ class TestIPRouteClass(unittest.TestCase):
         default["gateway"] = "192.168.4.254"
         with self.assertRaises(ValueError):
             self.bundle.update_default(default)
-        self.assertIn("interface", self.bundle.model.db)
+        self.assertIn("default", self.bundle.model.db)
 
     @patch.object(IPRoute, 'list_interfaces')
     def test__update_default__add_failed_cellular_connected(
@@ -405,7 +405,7 @@ class TestIPRouteClass(unittest.TestCase):
 
         def resp(code=200, data=None):
             self.assertEqual(200, code)
-            self.assertEqual("eth0", data["interface"])
+            self.assertEqual("eth0", data["default"])
         self.bundle._get_default(message=message, response=resp, test=True)
 
     def test__get_default__empty(self):


### PR DESCRIPTION
Dynamically check every 60 seconds; if default gateway interface is down, change to secondary.